### PR TITLE
Handle variable predicate query with joinCondition predicateObjectMap

### DIFF
--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/R2RMLMappingDocument.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/R2RMLMappingDocument.scala
@@ -55,18 +55,8 @@ class R2RMLMappingDocument(mappingFile : String) {
 		result;
 	}
 
-	def getPredicateObjectMapResources(triplesMapResources : List[Resource]) : List[Resource] = {
-		val result = {
-			if(triplesMapResources.isEmpty) {
-			  Nil;;
-			} else {
-				val resultHead =  this.getPredicateObjectMapResources(triplesMapResources.head);
-				val resultTail = this.getPredicateObjectMapResources(triplesMapResources.tail);
-				resultHead :::resultHead ::: resultTail;
-			}		  
-		}
-		result;
-	}
+	def getPredicateObjectMapResources(triplesMapResources : List[Resource]) : List[Resource] =
+		triplesMapResources.flatMap(this.getPredicateObjectMapResources(_))
 
 		
 	def getPredicateObjectMapResources(triplesMapResource : Resource) : List[Resource]= {

--- a/morph-r2rml-rdb-querytranslator/src/main/scala/es/upm/fi/dia/oeg/morph/rdb/querytranslator/MorphRDBAlphaGenerator.scala
+++ b/morph-r2rml-rdb-querytranslator/src/main/scala/es/upm/fi/dia/oeg/morph/rdb/querytranslator/MorphRDBAlphaGenerator.scala
@@ -122,7 +122,7 @@ extends MorphBaseAlphaGenerator(md,unfolder)
 			}		  
 		}
 		
-		val predicateURI = triple.getPredicate().getURI();
+		val predicateURI = pm.getMappedPredicateName(0)
 		(result, predicateURI);
 	}
 	

--- a/morph-r2rml/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/model/R2RMLTriplesMap.scala
+++ b/morph-r2rml/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/model/R2RMLTriplesMap.scala
@@ -50,21 +50,12 @@ extends MorphBaseClassMapping(predicateObjectMaps) with MorphR2RMLElement with I
 
 		return result;
 	}	
+
+	override def getPropertyMappings(propertyURI:String ) : Iterable[MorphBasePropertyMapping] =
+		this.predicateObjectMaps.filter(_.getMappedPredicateName(0).equals(propertyURI))
 	
-	override def getPropertyMappings(propertyURI:String ) 
-	: Iterable[MorphBasePropertyMapping] = {
-		val poms= this.predicateObjectMaps;
-		val result = poms.filter(pom => {
-				val predicateMapValue = pom.getPredicateMap(0).getOriginalValue();
-				predicateMapValue.equals(propertyURI)
-			})
-		
-		result;
-	}
-	
-	override def getPropertyMappings() : Iterable[MorphBasePropertyMapping] = {
-	  this.predicateObjectMaps
-	}
+	override def getPropertyMappings() : Iterable[MorphBasePropertyMapping] =
+		this.predicateObjectMaps
 	
 //	override def getRelationMappings() : java.util.Collection[IRelationMapping] = {
 //		val result = if(this.predicateObjectMaps != null) {


### PR DESCRIPTION
This pull request is a one-line fix (MorphRDBAlphaGenerator.scala:120) to let Morph-RDB handle queries where the predicate is a variable e.g. `SELECT * WHERE { <http://example.com/foo/1> ?p ?o . }` in cases where the predicateObjectMap uses a joinCondition, e.g. looking that up with a R2RML mapping file like the following.

```
<#TripleMap_foo>Wit
   a rr:TriplesMap ;
   rr:logicalTable [ rr:tableName "table_foo" ] ;
   rr:predicateObjectMap
       [ rr:objectMap
           [ rr:joinCondition [ rr:child "bar_id" ; rr:parent "id" ] ;
             rr.parentTriplesMap <#TripleMap_bar> ] ;
         rr.predicate <http://example.com/hasBar> ] ;
   rr:subjectMap
        [ rr:class <http://example.com/foo> ;
          rr:template "http://example.com/foo/{id}" ] .

<#TripleMap_bar>
  a rr:TriplesMap ;
  rr:logicalTable [ rr:tableName "table_bar" ];
  rr:subjectMap
       [ rr:class <http://example.com/bar> ;
         rr:template "http://example.com/bar/{id}" ] .
```

Currently, such triples are missed, and the console output shows the following:
```
 WARN [main] (MorphBaseQueryTranslator.scala:758) - -- Insatifiable sql while translating : http://example.com/hasBar in http://example.com/foo
 WARN [main] (MorphBaseQueryTranslator.scala:759) - ?p is not a URI node
 WARN [main] (MorphBaseQueryTranslator.scala:760) -
ERROR [main] (MorphRDBRunner.scala:76) - Exception occured: ?p is not a URI node
```

The code as written goes down a parsing path where the SPARQL query is pattern match on a triple where the predicate is known to be a variable (MorphBaseQueryTranslator.scala:732), but goes down a code path where it tries to do an operation on a predicate thought to be a fixed URI in that same triple.

A partial stack trace of the error is shown below

```
Exception in thread "main" java.lang.UnsupportedOperationException: ?p is not a URI node
	at com.hp.hpl.jena.graph.Node.getURI(Node.java:287)
	at es.upm.fi.dia.oeg.morph.rdb.querytranslator.MorphRDBAlphaGenerator.calculateAlphaPredicateObject(MorphRDBAlphaGenerator.scala:120)
	at es.upm.fi.dia.oeg.morph.rdb.querytranslator.MorphRDBAlphaGenerator.calculateAlpha(MorphRDBAlphaGenerator.scala:59)
	at es.upm.fi.dia.oeg.morph.base.querytranslator.MorphBaseQueryTranslator.transTP(MorphBaseQueryTranslator.scala:803)
	at es.upm.fi.dia.oeg.morph.base.querytranslator.MorphBaseQueryTranslator$$anonfun$7.apply(MorphBaseQueryTranslator.scala:753)
	at es.upm.fi.dia.oeg.morph.base.querytranslator.MorphBaseQueryTranslator$$anonfun$7.apply(MorphBaseQueryTranslator.scala:747)
...
```

(Note that this error is typically hidden at MorphBaseQueryTranslator.scala:757 which returns None when an Exception is thrown. That's a kind of dangerous exception catching which can hide real errors like this one.)

With my limited understanding of the current base, this fix looks up the URI instead from the property mapping, using the same field used to do filtering in  `R2RMLTriplesMap.getPropertyMappings(propertyURI)` (R2RMLTriplesMap.scala:55), aka `getMappedPredicateName(0)`. If this is the wrong place to look, let me know.

This pull request also simplifies some of the code for getPropertyMappings, and fixes a potential bug in R2RMLMappingDocument.scala (double concatenation of a list, resulting in duplicates).