### PR TITLE
Refactor inferrer

### DIFF
--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/model/MorphBaseMappingDocument.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/model/MorphBaseMappingDocument.scala
@@ -20,41 +20,26 @@ abstract class MorphBaseMappingDocument(val classMappings:Iterable[MorphBaseClas
 	def buildMetaData(connection:Connection, databaseName:String
 	    , databaseType:String);
 	
-	def getMappedClasses() : Iterable[String] = {
-		this.classMappings.map(cm => cm.getConceptName());
-	}
+	def getMappedClasses() : Iterable[String] =
+		this.classMappings.map(_.getConceptName)
 	
-	def getClassMappingsByClassURI(classURI:String ) = {
-	  this.classMappings.filter(
-	      cm => cm.getMappedClassURIs.exists(mappedClass => mappedClass.equals(classURI))
-	      )
-	}
+	def getClassMappingsByClassURI(classURI:String) =
+		this.classMappings.filter(_.getMappedClassURIs.exists(_.equals(classURI)))
 	
 	def getMappedProperties() : Iterable[String];
 	
-	def getClassMappingByPropertyUri(propertyUri:String) : Iterable[MorphBaseClassMapping] = {
-	  this.classMappings.filter(cm => {
-	    val pms = cm.getPropertyMappings(propertyUri);
-	    !pms.isEmpty
-	    })
-	}
+	def getClassMappingByPropertyUri(propertyUri:String) : Iterable[MorphBaseClassMapping] =
+	  this.classMappings.filter(_.getPropertyMappings(propertyUri).nonEmpty)
 
 	def getClassMappingByPropertyURIs(propertyURIs:Iterable[String]) 
-	: Iterable[MorphBaseClassMapping]  = {
-		this.classMappings.flatMap(cm => {
-			val pms = cm.propertyMappings;
-			val mappedPredicateNames = pms.map(pm => pm.getMappedPredicateNames).flatten.toSet;
-			
-			if(propertyURIs.toSet.subsetOf(mappedPredicateNames)) {
-			  Some(cm);
-			} else {None}
-		})
-	}
+	: Iterable[MorphBaseClassMapping] =
+		this.classMappings.filter(cm =>
+			propertyURIs.toSet.subsetOf(cm.propertyMappings.flatMap(_.getMappedPredicateNames).toSet)
+		)
 	
 	def getPropertyMappingsByPropertyURI(propertyURI:String ) 
-	: Iterable[MorphBasePropertyMapping] = {
-	  this.classMappings.map(cm => cm.getPropertyMappings(propertyURI)).flatten
-	}
+	: Iterable[MorphBasePropertyMapping] =
+	  this.classMappings.flatMap(_.getPropertyMappings(propertyURI))
 	
 	def getPossibleRange(predicateURI:String , cm:MorphBaseClassMapping ):Iterable[MorphBaseClassMapping];
 	


### PR DESCRIPTION
This pull request does some refactoring of MorphMappingInferrer, in preparation for my next task. This refactor _should_ have no visible difference in functionality, but the diffs should be looked at to verify this. (I didn't want to mix a large refactor with new functionality, so that's why this PR has no changes.)

The main features are:

* Use a `genericInferBGP()` method that takes a function that maps OpBGP to the node->class mappings. All the different inferences seemed to be identical in all ops except OpBGP, so this refactor made sense.
* Use a `genericInfer()` method for the common case where the BGP is processed one triple at a time then accumulated using addToInferredTypes.
* Remove explicit checks for null; none of the functions being called for which the null-checks were being done can return null.
* Replace the calculation of mapObjectTypesByObjectURIs inside `infer()` with what I believe to be an equivalent one-liner.
* Rewrite most of the `inferXByYURI()` methods with versions that use genericInfer/genericInferBGP, generated by extracting out just the subset of code inside the old "case OpBGP".
* Other code simplifications, such as removing `flatMap(Some/None)` idioms where a simple filter would do, or turn `.map().flatten` into `.flatMap()`, and turning lots of `map(x=>x.doSomething)` to `map(_.something)` for readability. Most of them were aimed at reducing the nesting depth so that I could understand the code without having to reason through a bunch of nested braces.

I know my Scala coding style can make the code a bit denser (especially my habit of using chained maps/filters and using "_" when possible for the arguments); I can re-expand out some of the code if you wish to keep closer to your existing style. I do find this more functional-programming code more understandable though.

This refactor also carries the risk of making it slightly more difficult to specialize some of these inferences if they differ in behavior in Ops other than OpBGP. Let me know if this is unacceptable.

--

The task I'm preparing for is trying to see if I can get OpTable and OpExtend to be able to pass through the inferrer (these currently crash with no match found in the case statements). OpTable is used for queries with a VALUES clause (BINDINGS in pre-1.1 SPARQL) such as:

```
SELECT * {
    ?s ?p ?o
}
VALUES ?s { <http://example.com/1> }
```

OpExtend is used in BIND clauses such as:

```
SELECT * {
    BIND(<http://example.com/1> AS ?s)
    ?s ?p ?o
}
```