### PR TITLE
Update MorphRDBNodeGenerator.scala

### DIFF
--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBNodeGenerator.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBNodeGenerator.scala
@@ -144,7 +144,8 @@ class MorphRDBNodeGenerator(properties:MorphProperties) {
       }
       */
 
-      val result = rs.getString(columnName);
+      //val result = rs.getString(columnName);
+      val result = rs.getObject(columnName).toString();
       result
     } catch {
       case e:Exception => {


### PR DESCRIPTION
This is an error when you try to get a String and the column is double precision.
E.g  
val result = rs.getString(columnName);
Solution is get the Object an apply toString
val result = rs.getObject(columnName).toString();