### PR TITLE
Suport for benchmarking times  of OBDA phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 bin
 target/
 log/
+mappings/
+properties/
+results/
+
 .idea
 .settings/
 .cache*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ log/
 mappings/
 properties/
 results/
+queries/
 
 .idea
 .settings/

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/Constants.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/Constants.scala
@@ -101,8 +101,8 @@ object Constants {
   val OUTPUT_DATE_PATTERN_PROP_NAME = "output.date.pattern";
   val OUTPUT_DATE_LOCALE_PROP_NAME = "output.date.locale";
 
-  val BENCHMARKING = "benchmarking"
-
+  //benchmarking
+  val  BENCHMARKFILE_PROP_NAME = "benchmark.file.path";
 
   //database
   val NO_OF_DATABASE_NAME_PROP_NAME = "no_of_database";

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/Constants.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/Constants.scala
@@ -101,6 +101,8 @@ object Constants {
   val OUTPUT_DATE_PATTERN_PROP_NAME = "output.date.pattern";
   val OUTPUT_DATE_LOCALE_PROP_NAME = "output.date.locale";
 
+  val BENCHMARKING = "benchmarking"
+
 
   //database
   val NO_OF_DATABASE_NAME_PROP_NAME = "no_of_database";

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphBenchmarking.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphBenchmarking.scala
@@ -57,7 +57,8 @@ class MorphBenchmarking (benchmark_file_path:String) {
 
     //add to the results those phases that have been benchmarked
     if (starting_time != -1) benchmark_result = benchmark_result + "Starting:" + starting_time.toString() + ","
-    if (rewriting_time != -1) benchmark_result = benchmark_result + "Rewriting:" + rewriting_time.toString() + ","
+    //do not include rewriting, as Morph does not include this phase
+    //if (rewriting_time != -1) benchmark_result = benchmark_result + "Rewriting:" + rewriting_time.toString() + ","
     if (translation_time != -1) benchmark_result = benchmark_result + "Translation:" + translation_time.toString() + ","
     if (execution_time != -1) benchmark_result = benchmark_result + "Execution:" + execution_time.toString() + ","
     if (materialization_time != -1) benchmark_result = benchmark_result + "Materialization:" + materialization_time.toString() + ","

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphBenchmarking.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphBenchmarking.scala
@@ -2,52 +2,79 @@ package es.upm.fi.dia.oeg.morph.base
 
 import java.io._
 
-class MorphBenchmarking {
+class MorphBenchmarking (benchmark_file_path:String) {
   // Times for the different OBDA phases (according to publication: The NPD Benchmark for OBDA Systems)
   // These times must be in miliseconds
-  private var _starting_time:Long = -1
-  private var _rewriting_time:Long = -1
-  private var _translation_time:Long = -1
-  private var _execution_time:Long = -1
+  private var starting_time:Long = -1
+  private var rewriting_time:Long = -1
+  private var translation_time:Long = -1
+  private var execution_time:Long = -1
 
-  private var _materialization_time:Long = -1
+  private var materialization_time:Long = -1
 
   //When each of the OBDA phases start, current_phase_start_time is updated
-  private var _current_phase_start_time:Long = System.currentTimeMillis()
+  private var current_phase_start_time:Long = System.currentTimeMillis()
 
-  def startRewritingPhase() = {
+
+  def finishStartingPhase() = {
     val current_time_millis = System.currentTimeMillis()
-    this._starting_time = current_time_millis - this._current_phase_start_time
+    this.starting_time = current_time_millis - this.current_phase_start_time
     //update the current_phase_start_time of the next OBDA phase
-    this._current_phase_start_time = current_time_millis
+    this.current_phase_start_time = current_time_millis
   }
 
-  def startTranslationPhase() = {
+  def finishRewritingPhase() = {
     val current_time_millis = System.currentTimeMillis()
-    this._rewriting_time = current_time_millis - this._current_phase_start_time
+    this.rewriting_time = current_time_millis - this.current_phase_start_time
     //update the current_phase_start_time of the next OBDA phase
-    this._current_phase_start_time = current_time_millis
+    this.current_phase_start_time = current_time_millis
   }
 
-  def startExecutionPhase() = {
+  def finishTranslationPhase() = {
     val current_time_millis = System.currentTimeMillis()
-    this._translation_time = current_time_millis - this._current_phase_start_time
+    this.translation_time = current_time_millis - this.current_phase_start_time
     //update the current_phase_start_time of the next OBDA phase
-    this._current_phase_start_time = current_time_millis
+    this.current_phase_start_time = current_time_millis
   }
 
-  def finishBenchmarking() = {
-    this._execution_time = System.currentTimeMillis() - this._current_phase_start_time
+  def finishExecutionPhase() = {
     //no more OBDA phases to benchmark, current_phase_start_time not updated
+    this.execution_time = System.currentTimeMillis() - this.current_phase_start_time
 
-    //store benchmark results
-    val file = new File("benchmark.txt")
-    val bw = new BufferedWriter(new FileWriter(file))
-    if (_starting_time != -1) bw.write("Starting time: " + _starting_time.toString() + "ms.")
-    if (_rewriting_time != -1) bw.write("Rewriting time: " + _rewriting_time.toString() + "ms.")
-    if (_translation_time != -1) bw.write("Translation time: " + _translation_time.toString() + "ms.")
-    if (_execution_time != -1) bw.write("Execution time: " + _execution_time.toString() + "ms.")
-    bw.close()
+    storeBenchmarkResults()
+  }
+
+  def finishMaterializationPhase() = {
+    //no more OBDA phases to benchmark, current_phase_start_time not updated
+    this.materialization_time = System.currentTimeMillis() - this.current_phase_start_time
+
+    storeBenchmarkResults()
+  }
+
+  private def storeBenchmarkResults(): Unit = {
+    //build a json string with the benchmark results
+    var benchmark_result: String = "{"
+
+    //add to the results those phases that have been benchmarked
+    if (starting_time != -1) benchmark_result = benchmark_result + "Starting:" + starting_time.toString() + ","
+    if (rewriting_time != -1) benchmark_result = benchmark_result + "Rewriting:" + rewriting_time.toString() + ","
+    if (translation_time != -1) benchmark_result = benchmark_result + "Translation:" + translation_time.toString() + ","
+    if (execution_time != -1) benchmark_result = benchmark_result + "Execution:" + execution_time.toString() + ","
+    if (materialization_time != -1) benchmark_result = benchmark_result + "Materialization:" + materialization_time.toString() + ","
+
+    //finish json string conveniently
+    if (benchmark_result.takeRight(1) == ",")
+      benchmark_result = benchmark_result.dropRight(1)
+    benchmark_result = benchmark_result + "}"
+
+    //if file path for benchmark is provided build and store benchmark results
+    if (benchmark_file_path != null) {
+      //store benchmark results
+      val file = new File(benchmark_file_path)
+      val bw = new BufferedWriter(new FileWriter(file))
+      bw.write(benchmark_result)
+      bw.close()
+    }
   }
 
 }

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphBenchmarking.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphBenchmarking.scala
@@ -1,0 +1,53 @@
+package es.upm.fi.dia.oeg.morph.base
+
+import java.io._
+
+class MorphBenchmarking {
+  // Times for the different OBDA phases (according to publication: The NPD Benchmark for OBDA Systems)
+  // These times must be in miliseconds
+  private var _starting_time:Long = -1
+  private var _rewriting_time:Long = -1
+  private var _translation_time:Long = -1
+  private var _execution_time:Long = -1
+
+  private var _materialization_time:Long = -1
+
+  //When each of the OBDA phases start, current_phase_start_time is updated
+  private var _current_phase_start_time:Long = System.currentTimeMillis()
+
+  def startRewritingPhase() = {
+    val current_time_millis = System.currentTimeMillis()
+    this._starting_time = current_time_millis - this._current_phase_start_time
+    //update the current_phase_start_time of the next OBDA phase
+    this._current_phase_start_time = current_time_millis
+  }
+
+  def startTranslationPhase() = {
+    val current_time_millis = System.currentTimeMillis()
+    this._rewriting_time = current_time_millis - this._current_phase_start_time
+    //update the current_phase_start_time of the next OBDA phase
+    this._current_phase_start_time = current_time_millis
+  }
+
+  def startExecutionPhase() = {
+    val current_time_millis = System.currentTimeMillis()
+    this._translation_time = current_time_millis - this._current_phase_start_time
+    //update the current_phase_start_time of the next OBDA phase
+    this._current_phase_start_time = current_time_millis
+  }
+
+  def finishBenchmarking() = {
+    this._execution_time = System.currentTimeMillis() - this._current_phase_start_time
+    //no more OBDA phases to benchmark, current_phase_start_time not updated
+
+    //store benchmark results
+    val file = new File("benchmark.txt")
+    val bw = new BufferedWriter(new FileWriter(file))
+    if (_starting_time != -1) bw.write("Starting time: " + _starting_time.toString() + "ms.")
+    if (_rewriting_time != -1) bw.write("Rewriting time: " + _rewriting_time.toString() + "ms.")
+    if (_translation_time != -1) bw.write("Translation time: " + _translation_time.toString() + "ms.")
+    if (_execution_time != -1) bw.write("Execution time: " + _execution_time.toString() + "ms.")
+    bw.close()
+  }
+
+}

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphProperties.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphProperties.scala
@@ -65,7 +65,7 @@ class MorphProperties extends java.util.Properties {
   var materializationDistinct:Boolean = false;
 
   //benchmarking
-  var benchmarkExecution:Boolean = false;
+  var benchmarkFilePath:Option[String] = None;
 
   //uri encoding
   //var uriEncode:Option[String]=None;
@@ -146,10 +146,19 @@ class MorphProperties extends java.util.Properties {
       Some(outputFilePropertyValue)
     } else { None }
 
+    val benchmarkFilePropertyValue = this.getProperty(Constants.BENCHMARKFILE_PROP_NAME);
+    this.benchmarkFilePath = if(benchmarkFilePropertyValue != null
+      && !benchmarkFilePropertyValue.equals("")) {
+      Some(benchmarkFilePropertyValue)
+    } else { None }
 
     if(configurationDirectory != null) {
       if(this.outputFilePath.isDefined) {
         this.outputFilePath = Some(configurationDirectory + outputFilePath.get);
+      }
+
+      if(this.benchmarkFilePath.isDefined) {
+        this.benchmarkFilePath = Some(configurationDirectory + benchmarkFilePath.get);
       }
 
       if(this.ontologyFilePath.isDefined) {
@@ -220,9 +229,6 @@ class MorphProperties extends java.util.Properties {
 
     this.transformString = this.readString(MorphProperties.TRANSFORM_STRING_PROPERTY, None);
     logger.debug("String transformation = " + this.transformString);
-
-    this.benchmarkExecution = this.readBoolean(Constants.BENCHMARKING, false);
-    logger.debug("Benchmarking = " + this.benchmarkExecution);
 
 
     //		val uriEncodeString = this.readString(MorphProperties.URI_ENCODE_PROPERTY, None);

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphProperties.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/MorphProperties.scala
@@ -64,7 +64,8 @@ class MorphProperties extends java.util.Properties {
   var mapDataTranslationOffsets:Map[String,String] = Map.empty;
   var materializationDistinct:Boolean = false;
 
-
+  //benchmarking
+  var benchmarkExecution:Boolean = false;
 
   //uri encoding
   //var uriEncode:Option[String]=None;
@@ -219,6 +220,10 @@ class MorphProperties extends java.util.Properties {
 
     this.transformString = this.readString(MorphProperties.TRANSFORM_STRING_PROPERTY, None);
     logger.debug("String transformation = " + this.transformString);
+
+    this.benchmarkExecution = this.readBoolean(Constants.BENCHMARKING, false);
+    logger.debug("Benchmarking = " + this.benchmarkExecution);
+
 
     //		val uriEncodeString = this.readString(MorphProperties.URI_ENCODE_PROPERTY, None);
     //		if(uriEncodeString.isDefined) {

--- a/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/engine/MorphBaseRunnerFactory.scala
+++ b/morph-base/src/main/scala/es/upm/fi/dia/oeg/morph/base/engine/MorphBaseRunnerFactory.scala
@@ -1,12 +1,11 @@
 package es.upm.fi.dia.oeg.morph.base.engine
 
 import java.sql.Connection
-import es.upm.fi.dia.oeg.morph.base.DBUtility
-import es.upm.fi.dia.oeg.morph.base.Constants
+
+import es.upm.fi.dia.oeg.morph.base.{Constants, DBUtility, MorphBenchmarking, MorphProperties}
 import es.upm.fi.dia.oeg.morph.base.model.MorphBaseMappingDocument
 import es.upm.fi.dia.oeg.morph.base.materializer.MorphBaseMaterializer
 import es.upm.fi.dia.oeg.morph.base.materializer.MaterializerFactory
-import es.upm.fi.dia.oeg.morph.base.MorphProperties
 import java.io.FileOutputStream
 import java.io.ObjectOutputStream
 import java.io.ByteArrayOutputStream
@@ -14,7 +13,8 @@ import java.io.OutputStream
 import java.io.Writer
 import java.io.FileWriter
 import java.io.StringWriter
-import org.apache.jena.query.QueryFactory;
+
+import org.apache.jena.query.QueryFactory
 import java.io.BufferedWriter
 import java.io.OutputStreamWriter
 import java.io.PrintWriter
@@ -175,6 +175,14 @@ abstract class MorphBaseRunnerFactory {
       Some(resultProcessorAux)
     } else { None }
 
+    //BUILDING BENCHMARK
+    val benchmark:MorphBenchmarking = if(morphProperties.benchmarkFilePath.isDefined) {
+      val benchmarkFileName = morphProperties.benchmarkFilePath.get;
+      new MorphBenchmarking(benchmarkFileName)
+    } else { new MorphBenchmarking(null) }
+
+
+
     val runner = this.createRunner(mappingDocument
       //        , dataSourceReader
       , unfolder
@@ -183,6 +191,7 @@ abstract class MorphBaseRunnerFactory {
       , queryTranslator
       ,  resultProcessor
       , writer
+      , benchmark
     )
 
     runner.ontologyFilePath = morphProperties.ontologyFilePath;
@@ -225,6 +234,7 @@ abstract class MorphBaseRunnerFactory {
                    , queryTranslator:Option[IQueryTranslator]
                    , resultProcessor:Option[AbstractQueryResultTranslator]
                    , outputStream:Writer
+                   , benchmark: MorphBenchmarking
                   ) : MorphBaseRunner;
 
   def readMappingDocumentFile(mappingDocumentFile:String

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphCSVRunner.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphCSVRunner.scala
@@ -3,6 +3,7 @@ package es.upm.fi.dia.oeg.morph.r2rml.rdb.engine
 import java.io.Writer
 //import java.util.Properties;
 import es.upm.fi.dia.oeg.morph.base.engine.{AbstractQueryResultTranslator, IQueryTranslator, MorphBaseRunner}
+import es.upm.fi.dia.oeg.morph.base.MorphBenchmarking
 import es.upm.fi.dia.oeg.morph.r2rml.model.R2RMLMappingDocument
 import org.slf4j.LoggerFactory
 
@@ -16,6 +17,7 @@ class MorphCSVRunner (
   , queryTranslator:Option[IQueryTranslator]
   , resultProcessor:Option[AbstractQueryResultTranslator]
   , outputStream:Writer
+	, benchmark: MorphBenchmarking
 ) extends MorphRDBRunner(
   mappingDocument
   , unfolder
@@ -23,6 +25,7 @@ class MorphCSVRunner (
   , queryTranslator
   , resultProcessor
   , outputStream
+	, benchmark
 ) {
 
 }

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphCSVRunnerFactory.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphCSVRunnerFactory.scala
@@ -2,7 +2,7 @@ package es.upm.fi.dia.oeg.morph.r2rml.rdb.engine
 
 //import java.util.Properties
 
-import es.upm.fi.dia.oeg.morph.base.MorphProperties
+import es.upm.fi.dia.oeg.morph.base.{MorphBenchmarking, MorphProperties}
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseRunner
 import es.upm.fi.dia.oeg.morph.base.model.MorphBaseMappingDocument
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseUnfolder
@@ -24,6 +24,7 @@ class MorphCSVRunnerFactory extends MorphRDBRunnerFactory {
     , queryTranslator:Option[IQueryTranslator]
     , resultProcessor:Option[AbstractQueryResultTranslator]
     , outputStream:Writer
+    , benchmark: MorphBenchmarking
   ) : MorphBaseRunner = { 
     val morphCSVRunner = new MorphCSVRunner(
       mappingDocument.asInstanceOf[R2RMLMappingDocument]
@@ -31,7 +32,8 @@ class MorphCSVRunnerFactory extends MorphRDBRunnerFactory {
       , dataTranslator.asInstanceOf[Option[MorphRDBDataTranslator]]
       , queryTranslator
       , resultProcessor
-      , outputStream)
+      , outputStream
+      , benchmark)
 
     morphCSVRunner;
 	}

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunner.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunner.scala
@@ -12,6 +12,8 @@ import es.upm.fi.dia.oeg.morph.base.engine.AbstractQueryResultTranslator
 import es.upm.fi.dia.oeg.morph.base.materializer.MorphBaseMaterializer
 import java.io.OutputStream
 import java.io.Writer
+
+import es.upm.fi.dia.oeg.morph.base.MorphBenchmarking
 import org.slf4j.LoggerFactory
 
 //import java.util.Properties
@@ -25,6 +27,7 @@ class MorphRDBRunner(mappingDocument:R2RMLMappingDocument
 										 , queryTranslator:Option[IQueryTranslator]
 										 , resultProcessor:Option[AbstractQueryResultTranslator]
 										 , outputStream:Writer
+										 , benchmark: MorphBenchmarking
 										) extends MorphBaseRunner(mappingDocument
 	//    , dataSourceReader
 	, unfolder
@@ -33,6 +36,7 @@ class MorphRDBRunner(mappingDocument:R2RMLMappingDocument
 	, queryTranslator
 	, resultProcessor
 	, outputStream
+	, benchmark
 ) {
 
 	//override val logger = Logger.getLogger(this.getClass());

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunner.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunner.scala
@@ -4,6 +4,7 @@ package es.upm.fi.dia.oeg.morph.r2rml.rdb.engine
 import es.upm.fi.dia.oeg.morph.r2rml.model.R2RMLMappingDocument
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseUnfolder
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseRunner
+import es.upm.fi.dia.oeg.morph.base.MorphBenchmarking
 import es.upm.fi.dia.oeg.morph.base.model.MorphBaseMappingDocument
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseDataSourceReader
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseDataTranslator
@@ -13,7 +14,6 @@ import es.upm.fi.dia.oeg.morph.base.materializer.MorphBaseMaterializer
 import java.io.OutputStream
 import java.io.Writer
 
-import es.upm.fi.dia.oeg.morph.base.MorphBenchmarking
 import org.slf4j.LoggerFactory
 
 //import java.util.Properties

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunnerFactory.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunnerFactory.scala
@@ -10,8 +10,9 @@ import es.upm.fi.dia.oeg.morph.base.engine.AbstractQueryResultTranslator
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseRunner
 import es.upm.fi.dia.oeg.morph.r2rml.model.R2RMLMappingDocument
 import es.upm.fi.dia.oeg.morph.base.materializer.MorphBaseMaterializer
-import es.upm.fi.dia.oeg.morph.base.MorphProperties
+import es.upm.fi.dia.oeg.morph.base.{MorphBenchmarking, MorphProperties}
 import java.sql.Connection
+
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseDataTranslator
 import es.upm.fi.dia.oeg.morph.base.engine.MorphBaseDataTranslator
 import es.upm.fi.dia.oeg.morph.base.engine.QueryTranslationOptimizerFactory
@@ -27,13 +28,15 @@ class MorphRDBRunnerFactory extends MorphBaseRunnerFactory{
       , queryTranslator:Option[IQueryTranslator]
       , resultProcessor:Option[AbstractQueryResultTranslator]
       , outputStream:Writer
+														, benchmark: MorphBenchmarking
 			) : MorphBaseRunner = { 
 					val morphRDBRunner = new MorphRDBRunner(mappingDocument.asInstanceOf[R2RMLMappingDocument]
 							, unfolder.asInstanceOf[MorphRDBUnfolder]
               , dataTranslator.asInstanceOf[Option[MorphRDBDataTranslator]]
               , queryTranslator
               , resultProcessor
-              , outputStream)
+              , outputStream
+					, benchmark)
 
 							morphRDBRunner;
 	}

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunnerFactory.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBRunnerFactory.scala
@@ -28,7 +28,7 @@ class MorphRDBRunnerFactory extends MorphBaseRunnerFactory{
       , queryTranslator:Option[IQueryTranslator]
       , resultProcessor:Option[AbstractQueryResultTranslator]
       , outputStream:Writer
-														, benchmark: MorphBenchmarking
+			, benchmark: MorphBenchmarking
 			) : MorphBaseRunner = { 
 					val morphRDBRunner = new MorphRDBRunner(mappingDocument.asInstanceOf[R2RMLMappingDocument]
 							, unfolder.asInstanceOf[MorphRDBUnfolder]

--- a/queries/q01.rq
+++ b/queries/q01.rq
@@ -1,0 +1,2 @@
+SELECT ?s ?o
+WHERE  { ?s <http://huawei.com/mgmt_ip> ?o . }

--- a/queries/q01.rq
+++ b/queries/q01.rq
@@ -1,2 +1,0 @@
-SELECT ?s ?o
-WHERE  { ?s <http://huawei.com/mgmt_ip> ?o . }


### PR DESCRIPTION
Benchmarking times for the different OBDA phases is included. Path of the benchmark results is indicated in the properties file via benchmark.file.path. Benchmark output is a json file.