### PR TITLE
Generate empty result set if any of the referenced columns of the term map has a NULL value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin
 target/
 log/
+
 mappings/
 properties/
 results/
@@ -16,6 +17,7 @@ morph.log
 *.*~
 morph-examples/examples/batch-result.nt
 .metadata
+morph-r2rml-rdb/src/main/resources
 
 # Ignore VS Code settings
 .vs/

--- a/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBNodeGenerator.scala
+++ b/morph-r2rml-rdb/src/main/scala/es/upm/fi/dia/oeg/morph/r2rml/rdb/engine/MorphRDBNodeGenerator.scala
@@ -384,8 +384,11 @@ class MorphRDBNodeGenerator(properties:MorphProperties) {
 
     //logger.info(s"replacements = ${replacements}")
     //logger.info(s"termMapTemplateString = ${termMapTemplateString}")
-    val node = if(replacements.isEmpty) {
+
+    val node = if(replacements.size < attributes.size) {
       //(this.translateData(termMap, termMapTemplateString, datatype), rawDBValues);
+
+      // if some of the replacements is null, no triples should be generated
       null
     } else {
       val templateWithDBValue = RegexUtility.replaceTokens(termMapTemplateString, replacements);


### PR DESCRIPTION
For term maps with more than one attribute, previous behabiour was generating results in those cases one of the referenced columns had a null value. Now, these situatuon generates no results. This is working for term maps in predicates and objects. At this moment, term maps in subjects are not allowed to have null values in any situation. 

Resolves #58 